### PR TITLE
feat(api): add server info endpoint for capability discovery

### DIFF
--- a/internal/httpapi/info.go
+++ b/internal/httpapi/info.go
@@ -1,0 +1,68 @@
+package httpapi
+
+import (
+	"net/http"
+	"time"
+)
+
+// ServerInfo represents the server's capabilities and configuration
+type ServerInfo struct {
+	APIVersion       string                       `json:"apiVersion"`
+	ServerTime       string                       `json:"serverTime"`
+	Entities         map[string]EntityCapability  `json:"entities"`
+	RecommendedBatch int                          `json:"recommendedBatch"`
+	Locking          LockingCapability            `json:"locking"`
+	MinClientVersion string                       `json:"minClientVersion"`
+}
+
+// EntityCapability describes capabilities for a specific entity type
+type EntityCapability struct {
+	MaxLimit int  `json:"maxLimit"`
+	Enabled  bool `json:"enabled"`
+}
+
+// LockingCapability describes sync locking/session support
+type LockingCapability struct {
+	Supported bool   `json:"supported"`
+	Mode      string `json:"mode"` // "session" or "none"
+}
+
+// Info handles GET /v1/sync/info
+// Returns server capabilities, API version, and supported features
+// This endpoint can be called without authentication to allow capability discovery
+func (s *Server) Info(w http.ResponseWriter, r *http.Request) {
+	info := ServerInfo{
+		APIVersion: "1.0",
+		ServerTime: time.Now().UTC().Format(time.RFC3339Nano),
+		Entities: map[string]EntityCapability{
+			"notes": {
+				MaxLimit: 1000,
+				Enabled:  true,
+			},
+			"tasks": {
+				MaxLimit: 1000,
+				Enabled:  true,
+			},
+			"comments": {
+				MaxLimit: 1000,
+				Enabled:  true,
+			},
+			"chats": {
+				MaxLimit: 1000,
+				Enabled:  true,
+			},
+			"chat_messages": {
+				MaxLimit: 1000,
+				Enabled:  true,
+			},
+		},
+		RecommendedBatch: 500,
+		Locking: LockingCapability{
+			Supported: true,
+			Mode:      "session",
+		},
+		MinClientVersion: "0.1.0",
+	}
+
+	writeJSON(w, http.StatusOK, info)
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -79,6 +79,9 @@ func (s *Server) Routes(jwt auth.JWTCfg) http.Handler {
 		w.Write([]byte("ok"))
 	})
 
+	// Server info / capability discovery (unauthenticated)
+	r.Get("/v1/sync/info", s.Info)
+
 	// All sync endpoints require authentication
 	r.Group(func(r chi.Router) {
 		r.Use(auth.Middleware(s.DB, jwt))


### PR DESCRIPTION
## Summary
- Add `GET /v1/sync/info` endpoint for server capability discovery

## Features
- Returns API version, server time, and entity capabilities
- Provides recommended batch size (500) and max limits (1000)
- Indicates locking/session support availability
- Specifies minimum client version requirement
- **Unauthenticated** endpoint to allow discovery before auth

## Response Example
```json
{
  "apiVersion": "1.0",
  "serverTime": "2025-11-06T12:34:56.789Z",
  "entities": {
    "notes": {"maxLimit": 1000, "enabled": true},
    "tasks": {"maxLimit": 1000, "enabled": true},
    "comments": {"maxLimit": 1000, "enabled": true},
    "chats": {"maxLimit": 1000, "enabled": true},
    "chat_messages": {"maxLimit": 1000, "enabled": true}
  },
  "recommendedBatch": 500,
  "locking": {
    "supported": true,
    "mode": "session"
  },
  "minClientVersion": "0.1.0"
}
```

## Benefits
- Clients can discover capabilities before syncing
- Enables graceful degradation for missing features
- Allows dynamic batch size negotiation
- Provides clear version compatibility information

## Related
- Part of Phase 2: Capability & Version Handshake
- Companion client PR will follow with ServerInfo models and integration

## Test Plan
- [ ] Verify endpoint returns 200 without authentication
- [ ] Confirm response structure matches spec
- [ ] Test with curl: `curl http://localhost:8081/v1/sync/info`

🤖 Generated with [Claude Code](https://claude.com/claude-code)