### PR TITLE
Fix token introspection authentication method

### DIFF
--- a/chart-mcpbridge/templates/deployment.yaml
+++ b/chart-mcpbridge/templates/deployment.yaml
@@ -106,6 +106,30 @@ spec:
               key: auth0-client-id-macos
               optional: true
         {{- end }}
+        {{- if or .Values.secrets.auth0IntrospectionClientId .Values.mcpbridge.auth0.introspection.clientId .Values.secrets.existingSecret }}
+        - name: AUTH0_INTROSPECTION_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "toolbridge-mcpbridge.secretName" . }}
+              key: auth0-introspection-client-id
+              optional: true
+        {{- end }}
+        {{- if or .Values.secrets.auth0IntrospectionClientSecret .Values.mcpbridge.auth0.introspection.clientSecret .Values.secrets.existingSecret }}
+        - name: AUTH0_INTROSPECTION_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "toolbridge-mcpbridge.secretName" . }}
+              key: auth0-introspection-client-secret
+              optional: true
+        {{- end }}
+        {{- if or .Values.secrets.auth0IntrospectionAudience .Values.mcpbridge.auth0.introspection.audience .Values.secrets.existingSecret }}
+        - name: AUTH0_INTROSPECTION_AUDIENCE
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "toolbridge-mcpbridge.secretName" . }}
+              key: auth0-introspection-audience
+              optional: true
+        {{- end }}
         {{- end }}
 
         # Health checks

--- a/chart-mcpbridge/templates/secret.yaml
+++ b/chart-mcpbridge/templates/secret.yaml
@@ -27,4 +27,19 @@ stringData:
   {{- else if .Values.mcpbridge.auth0.clientIdMacos }}
   auth0-client-id-macos: {{ .Values.mcpbridge.auth0.clientIdMacos | quote }}
   {{- end }}
+  {{- if .Values.secrets.auth0IntrospectionClientId }}
+  auth0-introspection-client-id: {{ .Values.secrets.auth0IntrospectionClientId | quote }}
+  {{- else if .Values.mcpbridge.auth0.introspection.clientId }}
+  auth0-introspection-client-id: {{ .Values.mcpbridge.auth0.introspection.clientId | quote }}
+  {{- end }}
+  {{- if .Values.secrets.auth0IntrospectionClientSecret }}
+  auth0-introspection-client-secret: {{ .Values.secrets.auth0IntrospectionClientSecret | quote }}
+  {{- else if .Values.mcpbridge.auth0.introspection.clientSecret }}
+  auth0-introspection-client-secret: {{ .Values.mcpbridge.auth0.introspection.clientSecret | quote }}
+  {{- end }}
+  {{- if .Values.secrets.auth0IntrospectionAudience }}
+  auth0-introspection-audience: {{ .Values.secrets.auth0IntrospectionAudience | quote }}
+  {{- else if .Values.mcpbridge.auth0.introspection.audience }}
+  auth0-introspection-audience: {{ .Values.mcpbridge.auth0.introspection.audience | quote }}
+  {{- end }}
 {{- end }}

--- a/chart-mcpbridge/values.yaml
+++ b/chart-mcpbridge/values.yaml
@@ -57,6 +57,18 @@ mcpbridge:
     clientIdWeb: ""
     clientIdMacos: ""
 
+    # Token introspection configuration (RFC 7662)
+    # Used as fallback when JWT parsing fails (e.g., opaque Auth0 tokens)
+    # Required when Claude Desktop omits audience parameter in authorization
+    introspection:
+      # M2M client ID for introspection (MUST be confidential client)
+      clientId: ""
+      # M2M client secret (stored in secret, never in values)
+      # This is a placeholder - actual value comes from secrets section
+      clientSecret: ""
+      # Optional audience override (defaults to syncApiAudience if not set)
+      audience: ""
+
   # Resource limits
   resources:
     requests:
@@ -129,6 +141,12 @@ secrets:
   auth0ClientIdWeb: ""
   auth0ClientIdMacos: ""
   auth0SyncApiAudience: ""
+
+  # Token introspection credentials (SENSITIVE - always use secrets)
+  # M2M client credentials for RFC 7662 token introspection
+  auth0IntrospectionClientId: ""
+  auth0IntrospectionClientSecret: ""
+  auth0IntrospectionAudience: ""  # Optional, defaults to syncApiAudience
 
   # Use existing secret instead of creating one
   existingSecret: ""

--- a/cmd/mcpbridge/README.md
+++ b/cmd/mcpbridge/README.md
@@ -113,7 +113,10 @@ Create a config file based on `config/mcpbridge_config.example.json`:
 }
 ```
 
-**Note on Token Introspection**: The `introspection` configuration enables fallback to OAuth 2.0 token introspection (RFC 7662) when JWT parsing fails. This is required for handling opaque access tokens issued by Auth0 when Claude Desktop omits the `audience` parameter in authorization requests. The introspection client must be a confidential M2M application with permission to introspect tokens.
+**Note on Token Introspection**: The `introspection` configuration enables fallback to OAuth 2.0 token introspection (RFC 7662) when JWT parsing fails. This is required for handling opaque access tokens issued by Auth0 when Claude Desktop omits the `audience` parameter in authorization requests. The introspection client must be a confidential M2M application with:
+- Permission to introspect tokens
+- `client_secret_post` authentication method configured in Auth0
+- Appropriate scopes/grants to validate tokens for your API audience
 
 ### Environment Variables
 
@@ -193,6 +196,97 @@ For local testing only, you can still run as stdio process:
 make build-mcp
 
 # Binary will be at: bin/mcpbridge
+```
+
+## Kubernetes/Helm Deployment
+
+The MCP bridge includes a Helm chart for Kubernetes deployment.
+
+### Prerequisites
+
+1. **Auth0 Configuration**:
+   - Create M2M application for token introspection
+   - Ensure it has `client_secret_post` authentication method
+   - Note the client ID and secret
+
+2. **Helm Values File**:
+
+Create a `values-production.yaml` file:
+
+```yaml
+image:
+  repository: ghcr.io/erauner12/toolbridge-mcpbridge
+  tag: "v0.1.0"
+
+mcpbridge:
+  apiBaseUrl: "http://toolbridge-api:80"
+  publicUrl: "https://mcp.toolbridge.com"
+  logLevel: "info"
+  allowedOrigins: "https://claude.ai,https://code.claude.com"
+
+  auth0:
+    domain: "your-tenant.us.auth0.com"
+    syncApiAudience: "https://api.toolbridge.example.com"
+    clientIdNative: "YOUR_NATIVE_CLIENT_ID"
+
+secrets:
+  # Token introspection credentials (REQUIRED for opaque token support)
+  auth0IntrospectionClientId: "YOUR_M2M_CLIENT_ID"
+  auth0IntrospectionClientSecret: "YOUR_M2M_CLIENT_SECRET"
+  auth0IntrospectionAudience: "https://api.toolbridge.example.com"
+
+ingress:
+  enabled: true
+  hostname: "mcp.toolbridge.com"
+
+certificate:
+  enabled: true
+  dnsNames:
+    - mcp.toolbridge.com
+```
+
+### Deploy
+
+```bash
+# Install the chart
+helm install mcpbridge ./chart-mcpbridge -f values-production.yaml
+
+# Or upgrade existing deployment
+helm upgrade mcpbridge ./chart-mcpbridge -f values-production.yaml
+
+# Check deployment status
+kubectl get pods -l app.kubernetes.io/name=toolbridge-mcpbridge
+kubectl logs -l app.kubernetes.io/name=toolbridge-mcpbridge --tail=100
+```
+
+### Verify Token Introspection
+
+After deployment, check logs for introspection initialization:
+
+```bash
+kubectl logs -l app.kubernetes.io/name=toolbridge-mcpbridge | grep introspection
+```
+
+Expected log entries:
+```json
+{"level":"info","endpoint":"https://your-tenant.us.auth0.com/oauth/token/introspect","clientId":"YOUR_M2M_CLIENT_ID","authMethod":"client_secret_post","message":"Token introspector initialized (credentials will be sent in form body)"}
+{"level":"info","introspectionEnabled":true,"message":"Token introspection fallback enabled"}
+```
+
+### Troubleshooting
+
+**401 errors during introspection:**
+- Verify M2M client uses `client_secret_post` authentication method in Auth0
+- Check client secret is correct in Kubernetes secret
+- Ensure M2M client has permission to introspect tokens
+
+**Pod not ready:**
+```bash
+# Check readiness probe
+kubectl describe pod -l app.kubernetes.io/name=toolbridge-mcpbridge
+
+# View detailed logs
+kubectl logs -l app.kubernetes.io/name=toolbridge-mcpbridge --tail=500
 ```
 
 ## Testing


### PR DESCRIPTION
Critical fix:
- Change TokenIntrospector to use client_secret_post authentication method instead of HTTP Basic Auth to match Auth0 M2M client config
- Credentials now sent in form body as required by Auth0

Helm chart enhancements:
- Add introspection configuration to values.yaml
- Wire introspection credentials through secret.yaml template
- Add environment variables in deployment.yaml for introspection
- Support both secrets section and direct values configuration

Observability improvements:
- Log authentication method (client_secret_post) on introspector init
- Include client ID and endpoint in initialization logs

Documentation updates:
- Add Kubernetes/Helm deployment section with complete example
- Document client_secret_post requirement for Auth0 M2M clients
- Include verification and troubleshooting steps
- Clarify introspection prerequisites

This fixes 401 errors when using token introspection by ensuring credentials are sent using the correct authentication method that matches the Auth0 client configuration.