### PR TITLE
Migrate authentication from Auth0 to WorkOS

### DIFF
--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -76,14 +76,14 @@ kill_timeout = "5s"
     timeout = "2s"
     grace_period = "10s"
 
-  # Health checks disabled - FastMCP SSE endpoint requires authentication
+  # Health checks disabled - FastMCP HTTP endpoint requires authentication
   # TODO: Add dedicated public health endpoint in future PR
   # [[services.http_checks]]
   #   interval = "30s"
   #   timeout = "5s"
   #   grace_period = "15s"
   #   method = "GET"
-  #   path = "/sse"
+  #   path = "/mcp"
   #   protocol = "http"
   #   tls_skip_verify = false
 
@@ -154,12 +154,12 @@ kill_timeout = "5s"
 #      fly deploy --config fly.staging.toml -a toolbridge-mcp-staging
 #
 #   5. Verify OAuth metadata:
-#      curl https://toolbridge-mcp-staging.fly.dev/.well-known/oauth-protected-resource
+#      curl https://toolbridge-mcp-staging.fly.dev/.well-known/oauth-protected-resource/mcp
 #
 #   6. Add connector in Claude Desktop:
 #      - Open https://claude.ai
 #      - Settings → Connectors → Add Connector
-#      - URL: https://toolbridge-mcp-staging.fly.dev
+#      - URL: https://toolbridge-mcp-staging.fly.dev/mcp
 #      - Authenticate via browser (WorkOS AuthKit OAuth flow)
 #
 # Update deployment:

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -24,6 +24,8 @@ TOOLBRIDGE_GO_API_BASE_URL=http://localhost:8080
 TOOLBRIDGE_AUTHKIT_DOMAIN=toolbridge.authkit.app
 
 # Public URL of this MCP server (used in OAuth metadata and resource identification)
+# NOTE: This should be the root URL without the /mcp path
+# The MCP endpoint will be available at: {PUBLIC_BASE_URL}/mcp
 TOOLBRIDGE_PUBLIC_BASE_URL=https://toolbridge-mcp-staging.fly.dev
 
 # Backend API Configuration

--- a/mcp/toolbridge_mcp/mcp_instance.py
+++ b/mcp/toolbridge_mcp/mcp_instance.py
@@ -19,7 +19,9 @@ settings.validate_authkit_config()
 # The MCP server acts as a protected resource that validates WorkOS tokens
 auth_provider = AuthKitProvider(
     authkit_domain=settings.authkit_domain,
-    # MCP's public URL (used in OAuth metadata)
+    # MCP's public URL (used in OAuth metadata) - must be root URL without /mcp path
+    # The AuthKitProvider will automatically append the MCP path to generate the
+    # resource metadata URL at /.well-known/oauth-protected-resource/mcp
     base_url=settings.public_base_url,
 )
 

--- a/mcp/toolbridge_mcp/server.py
+++ b/mcp/toolbridge_mcp/server.py
@@ -59,11 +59,13 @@ async def health_check() -> dict:
 
 
 if __name__ == "__main__":
-    # Run the MCP server with SSE transport for HTTP access
-    logger.info(f"🌐 Starting SSE transport on {settings.host}:{settings.port}")
-    
+    # Run the MCP server with Streamable HTTP transport at /mcp
+    logger.info(f"🌐 Starting HTTP transport on {settings.host}:{settings.port} at /mcp")
+    logger.info(f"✓ MCP endpoint: {settings.public_base_url}/mcp")
+
     mcp.run(
-        transport="sse",  # Use SSE transport for HTTP/web access
+        transport="http",  # Use Streamable HTTP transport
         host=settings.host,
         port=settings.port,
+        path="/mcp",  # MCP endpoint path
     )


### PR DESCRIPTION
Migrate the MCP server from SSE transport at /sse to Streamable HTTP transport at the explicit /mcp path. This aligns with MCP best practices and provides clearer endpoint semantics.

Changes:
- Update mcp/toolbridge_mcp/server.py: Change transport="sse" to transport="http" with path="/mcp", update startup logs
- Add clarifying comments in mcp/toolbridge_mcp/mcp_instance.py about base_url being root URL without /mcp path
- Update mcp/.env.example with notes about /mcp endpoint
- Update fly.staging.toml deployment comments to reference /mcp instead of /sse in health checks and connector examples
- Add comprehensive migration section to docs/MIGRATION-AUTH0-TO-WORKOS.md documenting the transport change, breaking impacts, and testing steps

Breaking Change: Clients using /sse must update to /mcp endpoint
OAuth metadata URL: /.well-known/oauth-protected-resource/mcp