### PR TITLE
feat: Configure MCP service for always-on (disable scale-to-zero)

### DIFF
--- a/fly.mcp.toml
+++ b/fly.mcp.toml
@@ -76,9 +76,9 @@ kill_timeout = "10s"
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = false
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
 # VM configuration

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -56,9 +56,9 @@ kill_timeout = "10s"
 [[services]]
   protocol = "tcp"
   internal_port = 8001
-  auto_stop_machines = true
+  auto_stop_machines = false
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
   [[services.ports]]
@@ -94,9 +94,9 @@ kill_timeout = "10s"
 [http_service]
   internal_port = 8001
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = false
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
   [http_service.concurrency]


### PR DESCRIPTION
## Summary

Configures Fly.io to keep MCP machines running 24/7 instead of auto-stopping when idle (scale-to-zero).

## Changes

**Configuration updates:**
- `auto_stop_machines = false` (was `true`)
- `min_machines_running = 1` (was `0`)
- `auto_start_machines = true` (unchanged, for future scale-up support)

**Files modified:**
- `fly.staging.toml` - Updated `[services]` and `[http_service]` sections
- `fly.mcp.toml` - Updated `[http_service]` section  
- `docs/DEPLOYMENT-FLYIO.md` - Added comprehensive "Scale-to-Zero vs Always-On Configuration" section

## Benefits

✅ **Zero cold start latency** - Instant response on every request  
✅ **Warm connections** - Persistent connections stay alive  
✅ **Predictable performance** - No 5-second cold starts after idle periods  
✅ **Production-ready** - Suitable for latency-sensitive applications

## Trade-offs

⚠️ **Continuous cost** - ~$3-5/month for shared-cpu-1x @ 512MB (instead of $0 when idle)  
⚠️ **No auto-savings** - Machine runs 24/7 regardless of traffic

## Documentation

The new documentation section explains:
- When to use scale-to-zero vs always-on
- Configuration examples for both modes
- How to switch between modes
- Cost and performance trade-offs

## Testing

- [ ] Review configuration changes
- [ ] Deploy to staging (when ready): `fly deploy --config fly.staging.toml -a toolbridge-mcp-staging`
- [ ] Verify machine stays running: `fly status -a toolbridge-mcp-staging`
- [ ] Monitor costs in Fly.io dashboard

## Notes

**This PR does NOT automatically deploy the changes.** You can merge this to have the configuration ready, then deploy when you decide the always-on mode is needed.

The graceful shutdown mechanism (SIGTERM handling from #52) works the same in both modes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)