### PR TITLE
feat(tasks): Set both status and done in ProcessTask/ArchiveTask (SRE-21)

### DIFF
--- a/internal/httpapi/rest_items.go
+++ b/internal/httpapi/rest_items.go
@@ -774,9 +774,10 @@ func (s *Server) ArchiveTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set archived status
+	// Set archived status - both status and done for compatibility
 	payload := existing.Payload
 	payload["status"] = "archived"
+	payload["done"] = true
 
 	item, err := s.TaskSvc.ApplyTaskMutation(ctx, userID, payload, syncservice.MutationOpts{})
 	if err != nil {
@@ -829,15 +830,18 @@ func (s *Server) ProcessTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Apply action
+	// Apply action - set both status and done for compatibility
 	payload := existing.Payload
 	switch req.Action {
 	case "start":
 		payload["status"] = "in_progress"
+		payload["done"] = false
 	case "complete":
 		payload["status"] = "completed"
+		payload["done"] = true
 	case "reopen":
 		payload["status"] = "open"
+		payload["done"] = false
 	default:
 		writeError(w, r, 400, "invalid action: "+req.Action)
 		return


### PR DESCRIPTION
## Summary
- Updates task REST handlers to set both `status` and `done` fields
- Ensures compatibility with new Jotty-style kanban client and legacy clients

## Changes
**ProcessTask handler** (`POST /v1/tasks/{uid}/process`):
- `start` → status=in_progress, done=false
- `complete` → status=completed, done=true
- `reopen` → status=open, done=false

**ArchiveTask handler** (`POST /v1/tasks/{uid}/archive`):
- status=archived, done=true

## Related
- Companion PR: erauner12/ToolBridge#198

## Test plan
- [ ] ProcessTask with action=start sets status=in_progress, done=false
- [ ] ProcessTask with action=complete sets status=completed, done=true
- [ ] ProcessTask with action=reopen sets status=open, done=false
- [ ] ArchiveTask sets status=archived, done=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)