### PR TITLE
feat(tasks): Add parent_uid JSONB index for nested subtasks (SRE-24)

### DIFF
--- a/migrations/0003_task_parent_uid.sql
+++ b/migrations/0003_task_parent_uid.sql
@@ -1,0 +1,20 @@
+-- Task parent_uid support for nested subtasks
+-- Phase 2: SRE-24 - Nested subtasks for tasks
+--
+-- The parentUid field is stored in payload_json (JSONB) for sync compatibility.
+-- This migration adds an optional expression index for future server-side filtering.
+
+-- Expression index on parentUid extracted from JSONB payload
+-- This enables efficient queries like: WHERE payload_json->>'parentUid' = 'some-uid'
+CREATE INDEX CONCURRENTLY IF NOT EXISTS task_parent_uid_idx 
+    ON task ((payload_json->>'parentUid'))
+    WHERE payload_json->>'parentUid' IS NOT NULL;
+
+-- Expression index for root tasks (no parent)
+-- This enables efficient queries for top-level tasks only
+CREATE INDEX CONCURRENTLY IF NOT EXISTS task_root_tasks_idx
+    ON task ((payload_json->>'parentUid'))
+    WHERE payload_json->>'parentUid' IS NULL;
+
+COMMENT ON INDEX task_parent_uid_idx IS 'Expression index for filtering tasks by parentUid from JSONB payload';
+COMMENT ON INDEX task_root_tasks_idx IS 'Expression index for filtering root tasks (no parent) from JSONB payload';


### PR DESCRIPTION
## Summary
- Add expression indexes on `task.payload_json` for `parentUid` field to support efficient server-side filtering of parent-child relationships
- Index for filtering tasks by `parentUid` (subtasks of a specific parent)
- Index for filtering root tasks only (no parent)

## Changes
- `migrations/0003_task_parent_uid.sql`: PostgreSQL migration with CONCURRENTLY indexes on JSONB expressions

## Related
- Linear: SRE-24
- Client PR: https://github.com/erauner12/ToolBridge/pull/201

## Test plan
- [ ] Apply migration to development database
- [ ] Verify indexes are created with `\di task_*` in psql
- [ ] Test query performance for parentUid filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)