### PR TITLE
fix(auth): Apply OAuth/PKCE security audit recommendations

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -89,6 +89,7 @@ func main() {
 	jwtCfg := auth.JWTCfg{
 		HS256Secret:       jwtSecret,
 		DevMode:           isDevMode,
+		Env:               env("ENV", ""), // Used to guard DevMode in production (log.Fatal if DevMode && Env=="prod")
 		Issuer:            jwtIssuer,
 		JWKSURL:           jwksURL,
 		Audience:          jwtAudience,
@@ -119,9 +120,10 @@ func main() {
 
 	// HTTP server setup
 	srv := &httpapi.Server{
-		DB:              pool,
-		RateLimitConfig: httpapi.DefaultRateLimitConfig,
-		JWTCfg:          jwtCfg,
+		DB:                  pool,
+		RateLimitConfig:     httpapi.DefaultRateLimitConfig,
+		AuthRateLimitConfig: httpapi.DefaultAuthRateLimitConfig, // Stricter limits for auth endpoints
+		JWTCfg:              jwtCfg,
 		WorkOSClient:    workosClient,
 		DefaultTenantID: defaultTenantID,
 		TenantAuthCache: tenantAuthCache,

--- a/mcp/toolbridge_mcp/auth/__init__.py
+++ b/mcp/toolbridge_mcp/auth/__init__.py
@@ -8,7 +8,8 @@ from toolbridge_mcp.auth.token_exchange import (
     TokenExchangeError,
     exchange_for_backend_jwt,
     issue_backend_jwt,
-    extract_user_id_from_backend_jwt,
+    extract_user_id_from_backend_jwt,  # DEPRECATED: Use _unsafe_extract_user_id_for_logging
+    _unsafe_extract_user_id_for_logging,
 )
 from toolbridge_mcp.auth.tenant_resolver import (
     TenantResolutionError,
@@ -20,7 +21,8 @@ __all__ = [
     "TokenExchangeError",
     "exchange_for_backend_jwt",
     "issue_backend_jwt",
-    "extract_user_id_from_backend_jwt",
+    "extract_user_id_from_backend_jwt",  # DEPRECATED: Use _unsafe_extract_user_id_for_logging
+    "_unsafe_extract_user_id_for_logging",
     "TenantResolutionError",
     "MultiOrganizationError",
     "resolve_tenant",


### PR DESCRIPTION
## Summary

Implements security audit recommendations for OAuth/PKCE authentication flow:

- **Fix duplicate middleware bug**: Removed redundant `SimpleTenantHeaderMiddleware` from REST CRUD routes (already applied at parent group level, causing double validation and potential log noise)
- **Add auth endpoint rate limiting**: New stricter rate limits (60 req/min, burst 20) for sensitive endpoints:
  - `POST /auth/token-exchange`
  - `GET /v1/auth/tenant`
  - `POST/GET/DELETE /v1/sync/sessions`
- **Add DevMode production guard**: Hard fail (`log.Fatal()`) if `DevMode=true` with `Env="prod"` to prevent accidental auth bypass in production
- **Clarify unsafe JWT helper**: Renamed `extract_user_id_from_backend_jwt` to `_unsafe_extract_user_id_for_logging` with explicit security warnings (backwards-compat alias maintained)
- **Document RS256 migration**: Added detailed migration plan for transitioning backend token signing from HS256 to RS256

## Files Changed

### Go Backend
- `internal/httpapi/router.go` - Remove duplicate middleware, add auth rate limit config
- `internal/httpapi/token_exchange.go` - Document RS256 migration path
- `internal/auth/jwt.go` - Add Env field and DevMode production guard
- `cmd/server/main.go` - Initialize AuthRateLimitConfig and Env in JWTCfg

### Python MCP
- `mcp/toolbridge_mcp/auth/token_exchange.py` - Rename unsafe function with security warnings
- `mcp/toolbridge_mcp/auth/__init__.py` - Export new function name

## Production Deployment Notes

The `Env` field is automatically populated from the `ENV` environment variable:
- `ENV=dev` → DevMode allowed (X-Debug-Sub header works)
- `ENV=prod` → DevMode blocked (log.Fatal if DevMode=true)
- `ENV` unset → DevMode allowed but disabled by default

No additional configuration required - `AuthRateLimitConfig` uses `DefaultAuthRateLimitConfig` automatically.

## Test plan

- [ ] Verify REST CRUD endpoints still work (tenant middleware applied once)
- [ ] Test rate limiting on auth endpoints (should get 429 after 60 requests/min)
- [ ] Verify DevMode guard triggers log.Fatal in prod environment
- [ ] Run existing MCP Python tests for token exchange

🤖 Generated with [Claude Code](https://claude.com/claude-code)