### PR TITLE
feat: Add Jenkinsfile for CI/CD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,68 @@
+// Jenkinsfile for toolbridge-api
+// Go-based API server CI pipeline
+
+@Library('homelab') _
+
+pipeline {
+    agent {
+        kubernetes {
+            yaml homelab.podTemplate('golang')
+        }
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+        timeout(time: 10, unit: 'MINUTES')
+        disableConcurrentBuilds()
+    }
+
+    stages {
+        stage('Build') {
+            steps {
+                container('golang') {
+                    sh '''
+                        echo "=== Building toolbridge-api ==="
+                        go build -v ./...
+                    '''
+                }
+            }
+        }
+
+        stage('Test') {
+            steps {
+                container('golang') {
+                    sh '''
+                        echo "=== Running tests ==="
+                        go test -v -race ./...
+                    '''
+                }
+            }
+        }
+
+        stage('Vet') {
+            steps {
+                container('golang') {
+                    sh '''
+                        echo "=== Running go vet ==="
+                        go vet ./...
+                    '''
+                }
+            }
+        }
+    }
+
+    post {
+        success {
+            script {
+                homelab.githubStatus('SUCCESS', 'Build passed')
+            }
+        }
+        failure {
+            script {
+                homelab.githubStatus('FAILURE', 'Build failed')
+                homelab.postFailurePrComment([repo: 'erauner12/toolbridge-api'])
+                homelab.notifyDiscordFailure()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Jenkinsfile to enable CI/CD via the homelab Jenkins instance using the shared library.

## Pipeline Stages

| Stage | Description |
|-------|-------------|
| Build | `go build -v ./...` |
| Test | `go test -v -race ./...` |
| Vet | `go vet ./...` |

## Notifications

On failure:
- GitHub commit status with Pipeline Graph View link
- PR comment with error context
- Discord webhook notification

## Prerequisites

- [x] Jenkins shared library (erauner12/homelab-k8s#1027)
- [x] Jenkins configured to discover this repo (erauner12/homelab-k8s#1030)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)